### PR TITLE
Update manual installation instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.reactlibrary.RNIndoorManagerPackage;` to the imports at the top of the file
   - Add `new RNIndoorManagerPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:


### PR DESCRIPTION
Android manual installation instruction points to the wrong file for making changes. This fixes the filename.